### PR TITLE
docs: add community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want `simple-ascii-chart-cli` to be a welcoming and respectful project for everyone. Contributors, users, and maintainers are expected to communicate with empathy, assume good intent, and keep discussions focused on improving the project.
+
+## Expected Behavior
+
+- Be respectful of different viewpoints and experience levels.
+- Give and receive feedback constructively.
+- Keep issues and pull requests focused, practical, and relevant.
+- Credit ideas, reports, and contributions where appropriate.
+
+## Unacceptable Behavior
+
+- Harassment, insults, threats, or discriminatory language.
+- Personal attacks or sustained disruption of project discussions.
+- Publishing private information without explicit permission.
+- Any conduct that would reasonably make participation unsafe or unwelcome.
+
+## Reporting
+
+If you experience or notice unacceptable behavior, please contact the project maintainers through GitHub. For sensitive reports, avoid sharing private details publicly and ask a maintainer for a private contact channel.
+
+Maintainers may remove comments, close issues or pull requests, or block participants when needed to keep the project healthy.
+
+## Scope
+
+This code of conduct applies to project spaces such as issues, pull requests, discussions, and other public project communication.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for considering a contribution to `simple-ascii-chart-cli`.
+
+## Getting Started
+
+1. Fork the repository and create a branch for your change.
+2. Install dependencies with `yarn install`.
+3. Make your changes with focused commits.
+4. Run the relevant checks before opening a pull request.
+
+## Useful Commands
+
+```bash
+yarn lint
+yarn test
+yarn build
+```
+
+To regenerate example snapshots after output changes, run:
+
+```bash
+yarn snapshots:generate
+```
+
+## Pull Requests
+
+- Keep pull requests focused on one change.
+- Include tests or snapshot updates when behavior changes.
+- Update documentation when options, usage, or requirements change.
+- Describe what changed and how you verified it.
+
+## Issues
+
+When reporting a bug, please include:
+
+- The command or API call you ran.
+- The expected output and the actual output.
+- Your Node.js version.
+- A small input example when possible.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,10 @@ npm test -- --runInBand
 
 For any questions or additional details, see the [documentation](https://simple-ascii-chart.vercel.app/).
 
+## Contributing
+
+Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and pull request guidance, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
+
 ## Support
 
 If this project helps you, consider supporting my open-source work:


### PR DESCRIPTION
Adds community documentation for contributors:

- Adds a Code of Conduct
- Adds a Contributing guide with setup and verification commands
- Links both documents from the README